### PR TITLE
Don't let a foreign criterion's context crash the server tick

### DIFF
--- a/common/src/main/java/io/ejekta/kambrik/criterion/KambrikCriterionApi.kt
+++ b/common/src/main/java/io/ejekta/kambrik/criterion/KambrikCriterionApi.kt
@@ -30,11 +30,26 @@ class KambrikCriterionApi internal constructor() {
     private val subscribers = mutableListOf<KambrikCriterionSubscriber>()
 
     fun handleGameTrigger(player: ServerPlayer, criterion: SimpleTrigger, predicate: SimpleTriggerPredicate) {
+        // The predicate handed to us belongs to the criterion that actually fired, and it usually
+        // closes over a context object of a type only that criterion understands. Subscribers and
+        // handlers legitimately test it against trigger instances parsed from elsewhere (data packs,
+        // bounties, quests), which for strongly-typed criteria blows up with a ClassCastException
+        // deep inside the other mod's `matches`. A mismatch just means "this instance is not the one
+        // that fired", so treat it as a non-match instead of letting it kill the server tick.
+        // Reported against Cobblemon's CaughtPokemonCriterion, but any mod with typed criterion
+        // contexts hits it.
+        val safePredicate = Predicate<SimpleTriggerInstance> { instance ->
+            try {
+                predicate.test(instance)
+            } catch (e: ClassCastException) {
+                false
+            }
+        }
         for (subscriber in subscribers) {
-            subscriber.handle(player, criterion, predicate)
+            subscriber.handle(player, criterion, safePredicate)
         }
         for ((condition, func) in handlers) {
-            val result = testAgainst(criterion, condition, predicate)
+            val result = testAgainst(criterion, condition, safePredicate)
             if (result) {
                 func(player)
             }


### PR DESCRIPTION
handleGameTrigger hands the firing criterion's predicate straight to subscribers and to registered handlers. That predicate closes over a context object belonging to the criterion that actually fired, so testing it against a trigger instance parsed from somewhere else (a data pack, a bounty, a quest) reaches the other criterion's matches with a context of the wrong type.

For vanilla criteria this is harmless, since their contexts are loosely typed. For mods with strongly-typed criterion contexts it throws a ClassCastException that escapes into the server tick and kills the world.

Observed with Cobblemon 1.7.3 + Bountiful 8.0.0-beta.2, on any Bountiful bounty using a criteria objective pointed at a Cobblemon trigger.

A type mismatch here only ever means 'this instance is not the one that fired', so wrap the predicate and treat ClassCastException as a non-match. Behaviour is unchanged for every case that did not already crash.